### PR TITLE
Allowing ChoiceToValue to have integers as value

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToValueTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToValueTransformer.php
@@ -34,8 +34,8 @@ class ChoiceToValueTransformer implements DataTransformerInterface
 
     public function reverseTransform($value)
     {
-        if (null !== $value && !is_string($value)) {
-            throw new TransformationFailedException('Expected a string or null.');
+        if (null !== $value && !is_string($value) && !is_int($value)) {
+            throw new TransformationFailedException('Expected a string, an integer or null.');
         }
 
         $choices = $this->choiceList->getChoicesForValues(array((string) $value));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 
| Bug fix?      | yes
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes/no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| License       | MIT

In ChoiceType.php, we have the following message : 

> // To avoid issues when the submitted choices are arrays (i.e. array to string conversions),
> // we have to ensure that all elements of the submitted choice data are NULL, strings or ints.

I understand ChoiceType should allow integers as value. However, this is not possible atm since the ChoiceToValueTransformer expects the value to be null or a string.

The following PR should allow that. 
