### PR TITLE
Allowing ChoiceToValue to have integers as value

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 | Bug fix?      | yes/no
 | New feature?  | yes/no <!-- don't forget to update src/**/CHANGELOG.md files -->
 | BC breaks?    | no     <!-- see https://symfony.com/bc -->
-| Deprecations? | yes/no <!-- don't forget to update UPGRADE-*.md files -->
+| Deprecations? | yes/no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
 | Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
 | Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
 | License       | MIT

--- a/CHANGELOG-2.7.md
+++ b/CHANGELOG-2.7.md
@@ -7,6 +7,10 @@ in 2.7 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.7.0...v2.7.1
 
+* 2.7.43 (2018-03-05)
+
+ * bug #26368 [WebProfilerBundle] Fix Debug toolbar breaks app (xkobal)
+
 * 2.7.42 (2018-02-28)
 
  * bug #26338 [Debug] Keep previous errors of Error instances (Philipp91)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -43,11 +43,11 @@ Symfony is the result of the work of many people who made the code better
  - Diego Saint Esteben (dosten)
  - Alexandre Salomé (alexandresalome)
  - William Durand (couac)
+ - Hamza Amrouche (simperfit)
  - ornicar
  - Francis Besset (francisbesset)
  - Iltar van der Berg (kjarli)
  - stealth35 ‏ (stealth35)
- - Hamza Amrouche (simperfit)
  - Alexander Mols (asm89)
  - Yonel Ceruto (yonelceruto)
  - Bulat Shakirzyanov (avalanche123)
@@ -57,8 +57,8 @@ Symfony is the result of the work of many people who made the code better
  - Henrik Bjørnskov (henrikbjorn)
  - Miha Vrhovnik
  - Diego Saint Esteben (dii3g0)
- - Dany Maillard (maidmaid)
  - Pierre du Plessis (pierredup)
+ - Dany Maillard (maidmaid)
  - Konstantin Kudryashov (everzet)
  - Kevin Bond (kbond)
  - Bilal Amarni (bamarni)
@@ -66,6 +66,7 @@ Symfony is the result of the work of many people who made the code better
  - Jérémy DERUSSÉ (jderusse)
  - Florin Patan (florinpatan)
  - Samuel ROZE (sroze)
+ - Tobias Nyholm (tobias)
  - Gábor Egyed (1ed)
  - Michel Weimerskirch (mweimerskirch)
  - Andrej Hudec (pulzarraider)
@@ -75,7 +76,6 @@ Symfony is the result of the work of many people who made the code better
  - Titouan Galopin (tgalopin)
  - Konstantin Myakshin (koc)
  - Christian Raue
- - Tobias Nyholm (tobias)
  - Arnout Boks (aboks)
  - Deni
  - Henrik Westphal (snc)
@@ -200,6 +200,7 @@ Symfony is the result of the work of many people who made the code better
  - Matthieu Bontemps (mbontemps)
  - apetitpa
  - Pierre Minnieur (pminnieur)
+ - Jannik Zschiesche (apfelbox)
  - fivestar
  - Dominique Bongiraud
  - Jeremy Livingston (jeremylivingston)
@@ -224,7 +225,6 @@ Symfony is the result of the work of many people who made the code better
  - Marcel Beerta (mazen)
  - gadelat (gadelat)
  - Loïc Faugeron
- - Jannik Zschiesche (apfelbox)
  - Hidde Wieringa (hiddewie)
  - Marco Pivetta (ocramius)
  - Rob Frawley 2nd (robfrawley)
@@ -697,6 +697,7 @@ Symfony is the result of the work of many people who made the code better
  - Nykopol (nykopol)
  - Jordan Deitch
  - Casper Valdemar Poulsen
+ - Remon van de Kamp
  - Josiah (josiah)
  - Joschi Kuphal
  - John Bohn (jbohn)
@@ -736,6 +737,7 @@ Symfony is the result of the work of many people who made the code better
  - Adrien Lucas (adrienlucas)
  - Zhuravlev Alexander (scif)
  - James Michael DuPont
+ - Xavier HAUSHERR
  - Tom Klingenberg
  - Christopher Hall (mythmakr)
  - Patrick Dawkins (pjcdawkins)
@@ -1102,7 +1104,6 @@ Symfony is the result of the work of many people who made the code better
  - Pierre Tachoire (krichprollsch)
  - Marc J. Schmidt (marcjs)
  - Marco Jantke
- - Remon van de Kamp
  - Saem Ghani
  - Clément LEFEBVRE
  - Conrad Kleinespel
@@ -1225,7 +1226,6 @@ Symfony is the result of the work of many people who made the code better
  - Sebastian Ionescu
  - Thomas Ploch
  - Simon Neidhold
- - Xavier HAUSHERR
  - Valentin VALCIU
  - Jeremiah VALERIE
  - Kevin Dew
@@ -1573,6 +1573,7 @@ Symfony is the result of the work of many people who made the code better
  - Vladimir Chernyshev (volch)
  - Yorkie Chadwick (yorkie76)
  - GuillaumeVerdon
+ - Philipp Keck
  - Ondrej Mirtes
  - akimsko
  - Youpie
@@ -1630,6 +1631,7 @@ Symfony is the result of the work of many people who made the code better
  - Jordan Hoff
  - znerol
  - Christian Eikermann
+ - Kai Eichinger
  - Antonio Angelino
  - Matt Fields
  - Niklas Keller

--- a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
@@ -95,7 +95,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
         $classMetadata = $classMetadatas[0];
 
         // Check whether the field exists and is nullable or not
-        if ($classMetadata->hasField($property)) {
+        if (isset($classMetadata->fieldMappings[$property])) {
             if (!$classMetadata->isNullable($property) && Type::BOOLEAN !== $classMetadata->getTypeOfField($property)) {
                 return new ValueGuess(true, Guess::HIGH_CONFIDENCE);
             }
@@ -124,7 +124,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
     public function guessMaxLength($class, $property)
     {
         $ret = $this->getMetadata($class);
-        if ($ret && $ret[0]->hasField($property) && !$ret[0]->hasAssociation($property)) {
+        if ($ret && isset($ret[0]->fieldMappings[$property]) && !$ret[0]->hasAssociation($property)) {
             $mapping = $ret[0]->getFieldMapping($property);
 
             if (isset($mapping['length'])) {
@@ -143,7 +143,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
     public function guessPattern($class, $property)
     {
         $ret = $this->getMetadata($class);
-        if ($ret && $ret[0]->hasField($property) && !$ret[0]->hasAssociation($property)) {
+        if ($ret && isset($ret[0]->fieldMappings[$property]) && !$ret[0]->hasAssociation($property)) {
             if (in_array($ret[0]->getTypeOfField($property), array(Type::DECIMAL, Type::FLOAT))) {
                 return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);
             }

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/DoctrineOrmTypeGuesserTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/DoctrineOrmTypeGuesserTest.php
@@ -33,21 +33,20 @@ class DoctrineOrmTypeGuesserTest extends TestCase
 
         // Simple field, not nullable
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('hasField')->with('field')->will($this->returnValue(true));
+        $classMetadata->fieldMappings['field'] = true;
         $classMetadata->expects($this->once())->method('isNullable')->with('field')->will($this->returnValue(false));
 
         $return[] = array($classMetadata, new ValueGuess(true, Guess::HIGH_CONFIDENCE));
 
         // Simple field, nullable
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('hasField')->with('field')->will($this->returnValue(true));
+        $classMetadata->fieldMappings['field'] = true;
         $classMetadata->expects($this->once())->method('isNullable')->with('field')->will($this->returnValue(true));
 
         $return[] = array($classMetadata, new ValueGuess(false, Guess::MEDIUM_CONFIDENCE));
 
         // One-to-one, nullable (by default)
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('hasField')->with('field')->will($this->returnValue(false));
         $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(true));
 
         $mapping = array('joinColumns' => array(array()));
@@ -57,7 +56,6 @@ class DoctrineOrmTypeGuesserTest extends TestCase
 
         // One-to-one, nullable (explicit)
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('hasField')->with('field')->will($this->returnValue(false));
         $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(true));
 
         $mapping = array('joinColumns' => array(array('nullable' => true)));
@@ -67,7 +65,6 @@ class DoctrineOrmTypeGuesserTest extends TestCase
 
         // One-to-one, not nullable
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('hasField')->with('field')->will($this->returnValue(false));
         $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(true));
 
         $mapping = array('joinColumns' => array(array('nullable' => false)));
@@ -77,7 +74,6 @@ class DoctrineOrmTypeGuesserTest extends TestCase
 
         // One-to-many, no clue
         $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $classMetadata->expects($this->once())->method('hasField')->with('field')->will($this->returnValue(false));
         $classMetadata->expects($this->once())->method('isAssociationWithSingleJoinColumn')->with('field')->will($this->returnValue(false));
 
         $return[] = array($classMetadata, null);

--- a/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
+++ b/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
@@ -54,8 +54,7 @@ class TwigExtractor extends AbstractFileExtractor implements ExtractorInterface
      */
     public function extract($resource, MessageCatalogue $catalogue)
     {
-        $files = $this->extractFiles($resource);
-        foreach ($files as $file) {
+        foreach ($this->extractFiles($resource) as $file) {
             try {
                 $this->extractTemplate(file_get_contents($file->getPathname()), $catalogue);
             } catch (Error $e) {

--- a/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\HttpCache;
 
-use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\HttpCache\HttpCache as BaseHttpCache;
 use Symfony\Component\HttpKernel\HttpCache\Esi;
 use Symfony\Component\HttpKernel\HttpCache\Store;
@@ -23,16 +23,16 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-abstract class HttpCache extends BaseHttpCache
+class HttpCache extends BaseHttpCache
 {
     protected $cacheDir;
     protected $kernel;
 
     /**
-     * @param HttpKernelInterface $kernel   An HttpKernelInterface instance
-     * @param string              $cacheDir The cache directory (default used if null)
+     * @param KernelInterface $kernel   A KernelInterface instance
+     * @param string          $cacheDir The cache directory (default used if null)
      */
-    public function __construct(HttpKernelInterface $kernel, $cacheDir = null)
+    public function __construct(KernelInterface $kernel, $cacheDir = null)
     {
         $this->kernel = $kernel;
         $this->cacheDir = $cacheDir;

--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -44,14 +44,14 @@ class Cookie
     /**
      * Sets a cookie.
      *
-     * @param string $name         The cookie name
-     * @param string $value        The value of the cookie
-     * @param string $expires      The time the cookie expires
-     * @param string $path         The path on the server in which the cookie will be available on
-     * @param string $domain       The domain that the cookie is available
-     * @param bool   $secure       Indicates that the cookie should only be transmitted over a secure HTTPS connection from the client
-     * @param bool   $httponly     The cookie httponly flag
-     * @param bool   $encodedValue Whether the value is encoded or not
+     * @param string      $name         The cookie name
+     * @param string      $value        The value of the cookie
+     * @param string|null $expires      The time the cookie expires
+     * @param string|null $path         The path on the server in which the cookie will be available on
+     * @param string      $domain       The domain that the cookie is available
+     * @param bool        $secure       Indicates that the cookie should only be transmitted over a secure HTTPS connection from the client
+     * @param bool        $httponly     The cookie httponly flag
+     * @param bool        $encodedValue Whether the value is encoded or not
      */
     public function __construct($name, $value, $expires = null, $path = null, $domain = '', $secure = false, $httponly = true, $encodedValue = false)
     {
@@ -112,8 +112,8 @@ class Cookie
     /**
      * Creates a Cookie instance from a Set-Cookie header value.
      *
-     * @param string $cookie A Set-Cookie header value
-     * @param string $url    The base URL
+     * @param string      $cookie A Set-Cookie header value
+     * @param string|null $url    The base URL
      *
      * @return static
      *
@@ -242,7 +242,7 @@ class Cookie
     /**
      * Gets the expires time of the cookie.
      *
-     * @return string The cookie expires time
+     * @return string|null The cookie expires time
      */
     public function getExpiresTime()
     {

--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -47,13 +47,13 @@ class CookieJar
             foreach ($this->cookieJar as $cookieDomain => $pathCookies) {
                 if ($cookieDomain) {
                     $cookieDomain = '.'.ltrim($cookieDomain, '.');
-                    if ($cookieDomain != substr('.'.$domain, -strlen($cookieDomain))) {
+                    if ($cookieDomain !== substr('.'.$domain, -\strlen($cookieDomain))) {
                         continue;
                     }
                 }
 
                 foreach ($pathCookies as $cookiePath => $namedCookies) {
-                    if ($cookiePath != substr($path, 0, strlen($cookiePath))) {
+                    if (0 !== strpos($path, $cookiePath)) {
                         continue;
                     }
                     if (isset($namedCookies[$name])) {

--- a/src/Symfony/Component/CssSelector/Parser/Tokenizer/TokenizerPatterns.php
+++ b/src/Symfony/Component/CssSelector/Parser/Tokenizer/TokenizerPatterns.php
@@ -44,7 +44,7 @@ class TokenizerPatterns
         $this->nonAsciiPattern = '[^\x00-\x7F]';
         $this->nmCharPattern = '[_a-z0-9-]|'.$this->escapePattern.'|'.$this->nonAsciiPattern;
         $this->nmStartPattern = '[_a-z]|'.$this->escapePattern.'|'.$this->nonAsciiPattern;
-        $this->identifierPattern = '(?:'.$this->nmStartPattern.')(?:'.$this->nmCharPattern.')*';
+        $this->identifierPattern = '-?(?:'.$this->nmStartPattern.')(?:'.$this->nmCharPattern.')*';
         $this->hashPattern = '#((?:'.$this->nmCharPattern.')+)';
         $this->numberPattern = '[+-]?(?:[0-9]*\.[0-9]+|[0-9]+)';
         $this->quotedStringPattern = '([^\n\r\f%s]|'.$this->stringEscapePattern.')*';

--- a/src/Symfony/Component/CssSelector/Tests/Parser/ParserTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Parser/ParserTest.php
@@ -186,6 +186,7 @@ class ParserTest extends TestCase
             array('foo:after', 'Element[foo]', 'after'),
             array('foo::selection', 'Element[foo]', 'selection'),
             array('lorem#ipsum ~ a#b.c[href]:empty::selection', 'CombinedSelector[Hash[Element[lorem]#ipsum] ~ Pseudo[Attribute[Class[Hash[Element[a]#b].c][href]]:empty]]', 'selection'),
+            array('video::-webkit-media-controls', 'Element[video]', '-webkit-media-controls'),
         );
     }
 

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -544,15 +544,16 @@ class ErrorHandler
                 }
             }
         }
+        $exceptionHandler = $this->exceptionHandler;
+        $this->exceptionHandler = null;
         try {
-            if (null !== $this->exceptionHandler) {
-                return \call_user_func($this->exceptionHandler, $exception);
+            if (null !== $exceptionHandler) {
+                return \call_user_func($exceptionHandler, $exception);
             }
             $handlerException = $handlerException ?: $exception;
         } catch (\Exception $handlerException) {
         } catch (\Throwable $handlerException) {
         }
-        $this->exceptionHandler = null;
         if ($exception === $handlerException) {
             self::$reservedMemory = null; // Disable the fatal error handler
             throw $exception; // Give back $exception to the native handler

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -530,4 +530,17 @@ class ErrorHandlerTest extends TestCase
             throw $e;
         }
     }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testCustomExceptionHandler()
+    {
+        $handler = new ErrorHandler();
+        $handler->setExceptionHandler(function ($e) use ($handler) {
+            $handler->handleException($e);
+        });
+
+        $handler->handleException(new \Exception());
+    }
 }

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -605,7 +605,7 @@ class Crawler extends \SplObjectStorage
                 }
             }
 
-            $data[] = $count > 1 ? $elements : $elements[0];
+            $data[] = 1 === $count ? $elements[0] : $elements;
         }
 
         return $data;

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -1039,8 +1039,6 @@ class Crawler extends \SplObjectStorage
      */
     private function createSubCrawler($nodes)
     {
-        $crawler = new static($nodes, $this->uri, $this->baseHref);
-
-        return $crawler;
+        return new static($nodes, $this->uri, $this->baseHref);
     }
 }

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -113,7 +113,7 @@ class ChoiceFormField extends FormField
     /**
      * Sets the value of the field.
      *
-     * @param string $value The value of the field
+     * @param string|array $value The value of the field
      *
      * @throws \InvalidArgumentException When value type provided is not correct
      */

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -97,14 +97,14 @@ class ChoiceFormField extends FormField
     }
 
     /**
-     * Ticks a checkbox.
+     * Unticks a checkbox.
      *
      * @throws \LogicException When the type provided is not correct
      */
     public function untick()
     {
         if ('checkbox' !== $this->type) {
-            throw new \LogicException(sprintf('You cannot tick "%s" as it is not a checkbox (%s).', $this->name, $this->type));
+            throw new \LogicException(sprintf('You cannot untick "%s" as it is not a checkbox (%s).', $this->name, $this->type));
         }
 
         $this->setValue(false);

--- a/src/Symfony/Component/DomCrawler/Field/InputFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/InputFormField.php
@@ -32,11 +32,12 @@ class InputFormField extends FormField
             throw new \LogicException(sprintf('An InputFormField can only be created from an input or button tag (%s given).', $this->node->nodeName));
         }
 
-        if ('checkbox' === strtolower($this->node->getAttribute('type'))) {
+        $type = strtolower($this->node->getAttribute('type'));
+        if ('checkbox' === $type) {
             throw new \LogicException('Checkboxes should be instances of ChoiceFormField.');
         }
 
-        if ('file' === strtolower($this->node->getAttribute('type'))) {
+        if ('file' === $type) {
             throw new \LogicException('File inputs should be instances of FileFormField.');
         }
 

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -369,6 +369,7 @@ EOF
 
         $this->assertEquals(array('One', 'Two', 'Three'), $crawler->extract('_text'), '->extract() returns an array of extracted data from the node list');
         $this->assertEquals(array(array('One', 'first'), array('Two', ''), array('Three', '')), $crawler->extract(array('_text', 'class')), '->extract() returns an array of extracted data from the node list');
+        $this->assertEquals(array(array(), array(), array()), $crawler->extract(array()), '->extract() returns empty arrays if the attribute list is empty');
 
         $this->assertEquals(array(), $this->createTestCrawler()->filterXPath('//ol')->extract('_text'), '->extract() returns an empty array if the node list is empty');
     }

--- a/src/Symfony/Component/Form/ChoiceList/LegacyChoiceListAdapter.php
+++ b/src/Symfony/Component/Form/ChoiceList/LegacyChoiceListAdapter.php
@@ -133,9 +133,7 @@ class LegacyChoiceListAdapter implements ChoiceListInterface
         $this->values = array();
         $this->structuredValues = $this->adaptedList->getValues();
 
-        $innerChoices = $this->adaptedList->getChoices();
-
-        foreach ($innerChoices as $index => $choice) {
+        foreach ($this->adaptedList->getChoices() as $index => $choice) {
             $value = $this->structuredValues[$index];
             $this->values[] = $value;
             $this->choices[$value] = $choice;

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -81,6 +81,7 @@ class FormType extends BaseType
             }
         }
 
+        $formConfig = $form->getConfig();
         $view->vars = array_replace($view->vars, array(
             'read_only' => $readOnly,
             'errors' => $form->getErrors(),
@@ -92,9 +93,9 @@ class FormType extends BaseType
             'pattern' => isset($options['attr']['pattern']) ? $options['attr']['pattern'] : null, // Deprecated
             'size' => null,
             'label_attr' => $options['label_attr'],
-            'compound' => $form->getConfig()->getCompound(),
-            'method' => $form->getConfig()->getMethod(),
-            'action' => $form->getConfig()->getAction(),
+            'compound' => $formConfig->getCompound(),
+            'method' => $formConfig->getMethod(),
+            'action' => $formConfig->getAction(),
             'submitted' => $form->isSubmitted(),
         ));
     }

--- a/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
@@ -61,9 +61,7 @@ class ValidationListener implements EventSubscriberInterface
 
         if ($form->isRoot()) {
             // Validate the form in group "Default"
-            $violations = $this->validator->validate($form);
-
-            foreach ($violations as $violation) {
+            foreach ($this->validator->validate($form) as $violation) {
                 // Allow the "invalid" constraint to be put onto
                 // non-synchronized forms
                 // ConstraintViolation::getConstraint() must not expect to provide a constraint as long as Symfony\Component\Validator\ExecutionContext exists (before 3.0)

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -261,12 +261,8 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
         $classMetadata = $this->metadataFactory->getMetadataFor($class);
 
         if ($classMetadata instanceof ClassMetadataInterface && $classMetadata->hasPropertyMetadata($property)) {
-            $memberMetadatas = $classMetadata->getPropertyMetadata($property);
-
-            foreach ($memberMetadatas as $memberMetadata) {
-                $constraints = $memberMetadata->getConstraints();
-
-                foreach ($constraints as $constraint) {
+            foreach ($classMetadata->getPropertyMetadata($property) as $memberMetadata) {
+                foreach ($memberMetadata->getConstraints() as $constraint) {
                     if ($guess = $closure($constraint)) {
                         $guesses[] = $guess;
                     }

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.7.43';
-    const VERSION_ID = 20743;
+    const VERSION = '2.7.44-DEV';
+    const VERSION_ID = 20744;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 7;
-    const RELEASE_VERSION = 43;
-    const EXTRA_VERSION = '';
+    const RELEASE_VERSION = 44;
+    const EXTRA_VERSION = 'DEV';
 
     const END_OF_MAINTENANCE = '05/2018';
     const END_OF_LIFE = '05/2019';

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -58,12 +58,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $loadClassCache;
 
-    const VERSION = '2.7.43-DEV';
+    const VERSION = '2.7.43';
     const VERSION_ID = 20743;
     const MAJOR_VERSION = 2;
     const MINOR_VERSION = 7;
     const RELEASE_VERSION = 43;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '05/2018';
     const END_OF_LIFE = '05/2019';

--- a/src/Symfony/Component/Intl/Intl.php
+++ b/src/Symfony/Component/Intl/Intl.php
@@ -15,6 +15,7 @@ use Symfony\Component\Intl\Data\Bundle\Reader\JsonBundleReader;
 use Symfony\Component\Intl\Data\Bundle\Reader\BufferedBundleReader;
 use Symfony\Component\Intl\Data\Bundle\Reader\BundleEntryReader;
 use Symfony\Component\Intl\Data\Bundle\Reader\BundleEntryReaderInterface;
+use Symfony\Component\Intl\Data\Provider\LocaleDataProvider;
 use Symfony\Component\Intl\Data\Provider\ScriptDataProvider;
 use Symfony\Component\Intl\ResourceBundle\CurrencyBundle;
 use Symfony\Component\Intl\ResourceBundle\CurrencyBundleInterface;
@@ -259,6 +260,11 @@ final class Intl
                 new JsonBundleReader(),
                 self::BUFFER_SIZE
             ));
+            $localeDataProvider = new LocaleDataProvider(
+                self::getDataDirectory().'/'.self::LOCALE_DIR,
+                self::$entryReader
+            );
+            self::$entryReader->setLocaleAliases($localeDataProvider->getAliases());
         }
 
         return self::$entryReader;

--- a/src/Symfony/Component/Intl/Tests/IntlTest.php
+++ b/src/Symfony/Component/Intl/Tests/IntlTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Intl\Tests;
+
+use Symfony\Component\Intl\Intl;
+use PHPUnit\Framework\TestCase;
+
+class IntlTest extends TestCase
+{
+    /**
+     * @requires extension intl
+     */
+    public function testIsExtensionLoadedChecksIfIntlExtensionIsLoaded()
+    {
+        $this->assertTrue(Intl::isExtensionLoaded());
+    }
+
+    public function testGetCurrencyBundleCreatesTheCurrencyBundle()
+    {
+        $this->assertInstanceOf('Symfony\Component\Intl\ResourceBundle\CurrencyBundleInterface', Intl::getCurrencyBundle());
+    }
+
+    public function testGetLanguageBundleCreatesTheLanguageBundle()
+    {
+        $this->assertInstanceOf('Symfony\Component\Intl\ResourceBundle\LanguageBundleInterface', Intl::getLanguageBundle());
+    }
+
+    public function testGetLocaleBundleCreatesTheLocaleBundle()
+    {
+        $this->assertInstanceOf('Symfony\Component\Intl\ResourceBundle\LocaleBundleInterface', Intl::getLocaleBundle());
+    }
+
+    public function testGetRegionBundleCreatesTheRegionBundle()
+    {
+        $this->assertInstanceOf('Symfony\Component\Intl\ResourceBundle\LocaleBundleInterface', Intl::getLocaleBundle());
+    }
+
+    public function testGetIcuVersionReadsTheVersionOfInstalledIcuLibrary()
+    {
+        $this->assertStringMatchesFormat('%d.%d', Intl::getIcuVersion());
+    }
+
+    public function testGetIcuDataVersionReadsTheVersionOfInstalledIcuData()
+    {
+        $this->assertStringMatchesFormat('%d.%d', Intl::getIcuDataVersion());
+    }
+
+    public function testGetIcuStubVersionReadsTheVersionOfBundledStubs()
+    {
+        $this->assertStringMatchesFormat('%d.%d', Intl::getIcuStubVersion());
+    }
+
+    public function testGetDataDirectoryReturnsThePathToIcuData()
+    {
+        $this->assertTrue(is_dir(Intl::getDataDirectory()));
+    }
+
+    /**
+     * @requires extension intl
+     */
+    public function testLocaleAliasesAreLoaded()
+    {
+        \Locale::setDefault('zh_TW');
+        $countryNameZhTw = Intl::getRegionBundle()->getCountryName('AD');
+
+        \Locale::setDefault('zh_Hant_TW');
+        $countryNameHantZhTw = Intl::getRegionBundle()->getCountryName('AD');
+
+        \Locale::setDefault('zh');
+        $countryNameZh = Intl::getRegionBundle()->getCountryName('AD');
+
+        $this->assertSame($countryNameZhTw, $countryNameHantZhTw, 'zh_TW is an alias to zh_Hant_TW');
+        $this->assertNotSame($countryNameZh, $countryNameZhTw, 'zh_TW does not fall back to zh');
+    }
+}

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -48,7 +48,7 @@ class ClassMetadata extends ElementMetadata implements ClassMetadataInterface
     public $defaultGroup;
 
     /**
-     * @var MemberMetadata[]
+     * @var MemberMetadata[][]
      *
      * @internal This property is public in order to reduce the size of the
      *           class' serialized representation. Do not access it. Use


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.7 
| Bug fix?      | yes
| New feature?  | yes <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes/no <!-- don't forget to update UPGRADE-*.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| License       | MIT

In ChoiceType.php, we have the following message : 

> // To avoid issues when the submitted choices are arrays (i.e. array to string conversions),
> // we have to ensure that all elements of the submitted choice data are NULL, strings or ints.

I understand ChoiceType should allow integers as value. However, this is not possible atm since the ChoiceToValueTransformer expects the value to be null or a string.

The following PR should allow that. 
